### PR TITLE
Fix required engine version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "homepage": "https://github.com/Unibeautify/unibeautify-cli#readme",
   "engines": {
-    "node": ">=4"
+    "node": ">=6.0.0"
   },
   "devDependencies": {
     "npm-run-all": "^3.0.0",


### PR DESCRIPTION
Currently, on 5.5.0 for example, you can install the package without a warning but running the code produces a SyntaxError (see [Issue #5](Unibeautify/unibeautify-cli#5)). Use of new language features require a more recent engine version as compared to the one specified as a min. requirement in the package.json. This change corrects the engine version requirement in order to warn users with incompatible versions during installation.