### PR TITLE
 Only write heading in blue if stdout is terminal

### DIFF
--- a/src/commands/BaseCommand.ts
+++ b/src/commands/BaseCommand.ts
@@ -1,9 +1,15 @@
+import chalk from "chalk";
+
 export abstract class BaseCommand {
   protected stdout: NodeJS.WriteStream = process.stdout;
   protected stderr: NodeJS.WriteStream = process.stderr;
 
   protected writeOut(text: string): void {
     this.stdout.write(text + "\n");
+  }
+
+  protected writeOutHeading(text: string): void {
+    this.writeOut(this.stdout.isTTY ? chalk.blue(text) : text);
   }
 
   protected writeError(text: string): void {

--- a/src/commands/SupportCommand.ts
+++ b/src/commands/SupportCommand.ts
@@ -1,5 +1,3 @@
-import chalk from "chalk";
-
 import {
   getSupportedLanguages,
   findInstalledBeautifiers,
@@ -49,7 +47,7 @@ export class SupportCommand extends BaseCommand {
 
   private listPrinter = (info: SupportInfo) => {
     Object.keys(info).forEach(section => {
-      this.writeOut(chalk.blue(`Supported ${section}`));
+      this.writeOutHeading(`Supported ${section}`);
       const items = info[section];
       items.forEach((item, index) => this.writeOut(`${index + 1}. ${item}`));
     });

--- a/test/commands/__snapshots__/SupportCommand.spec.ts.snap
+++ b/test/commands/__snapshots__/SupportCommand.spec.ts.snap
@@ -504,7 +504,7 @@ exports[`SupportCommand Support without JSON installed beautifiers 1`] = `
 Object {
   "exitCode": 0,
   "stderr": "",
-  "stdout": "[34mSupported beautifiers[39m
+  "stdout": "Supported beautifiers
 1. @unibeautify/beautifier-eslint
 ",
 }
@@ -514,7 +514,7 @@ exports[`SupportCommand Support without JSON languages 1`] = `
 Object {
   "exitCode": 0,
   "stderr": "",
-  "stdout": "[34mSupported languages[39m
+  "stdout": "Supported languages
 1. 1C Enterprise
 2. ABAP
 3. ABNF
@@ -1002,7 +1002,7 @@ exports[`SupportCommand Support without JSON supported languages 1`] = `
 Object {
   "exitCode": 0,
   "stderr": "",
-  "stdout": "[34mSupported languages[39m
+  "stdout": "Supported languages
 1. JSX
 2. JavaScript
 ",


### PR DESCRIPTION
Adds a new method `writeOutHeading` to the `BaseCommand` class.

Fixes some of the failing unit tests in #95.